### PR TITLE
remove `using System.Drawing` which resolves build namespace error

### DIFF
--- a/src/Helper/ProxyForms/Application.cs
+++ b/src/Helper/ProxyForms/Application.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;

--- a/src/Helper/ProxyForms/Control.cs
+++ b/src/Helper/ProxyForms/Control.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Runtime.InteropServices;
 using XnaToFna.ProxyDrawing;
 

--- a/src/Helper/ProxyForms/Cursor.cs
+++ b/src/Helper/ProxyForms/Cursor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
 using System.Runtime.InteropServices;
 using XnaToFna.ProxyDrawing;

--- a/src/Helper/ProxyForms/Message.cs
+++ b/src/Helper/ProxyForms/Message.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Security.Permissions;


### PR DESCRIPTION
These appear to have been left in there by accident. Prevents building with xbuild on OpenBSD.